### PR TITLE
Fix new subtypes separation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# development
+.idea
+.vscode
+
 # dependencies
 /node_modules
 /.pnp

--- a/src/utils/ruleChangeTransform.tsx
+++ b/src/utils/ruleChangeTransform.tsx
@@ -131,11 +131,12 @@ function detectChanges<T extends Change>(ruleText: string, type: ConstructorOf<T
 function getActualSubtypeChanges(text: TextBlock[]): string[] {
   return text
     .filter((e) => e instanceof Change)
-    .map((e) => e.toString().replaceAll(/[,.]/g, ""))
+    .map((e) => e.toString())
     .reduce((acc: string[], val: string) => {
-      acc.push(...val.split(" "));
+      acc.push(...val.split(/[,.] ?(?:and )?/));
       return acc;
-    }, []);
+    }, [])
+    .filter((change) => change !== "");
 }
 
 /**


### PR DESCRIPTION
Fixes #17.

Plane types and creature types can be more than one word, so we can't use a space to separate those subtypes. Instead, we now use the commas between those subtypes as the actual separators.